### PR TITLE
add bz2 decompression option for historical stream generator

### DIFF
--- a/betfairlightweight/endpoints/streaming.py
+++ b/betfairlightweight/endpoints/streaming.py
@@ -1,3 +1,5 @@
+import os
+
 from ..baseclient import BaseClient
 from ..streaming import (
     BaseListener,
@@ -5,6 +7,7 @@ from ..streaming import (
     BetfairStream,
     HistoricalStream,
     HistoricalGeneratorStream,
+    HistoricalGeneratorStreamBz2
 )
 
 
@@ -77,6 +80,7 @@ class Streaming:
         listener: BaseListener = None,
         operation: str = "marketSubscription",
         unique_id: int = 0,
+        compression: str = None
     ) -> HistoricalGeneratorStream:
         """
         Uses generator listener/cache to parse betfair
@@ -91,4 +95,11 @@ class Streaming:
         :rtype: HistoricalGeneratorStream
         """
         listener = listener if listener else StreamListener()
-        return HistoricalGeneratorStream(file_path, listener, operation, unique_id)
+        if compression == "bz2" or os.path.splitext(file_path)[1] == ".bz2":
+            return HistoricalGeneratorStreamBz2(
+                file_path, listener, operation, unique_id
+                )
+        else:
+            return HistoricalGeneratorStream(
+                file_path, listener, operation, unique_id
+                )

--- a/betfairlightweight/streaming/__init__.py
+++ b/betfairlightweight/streaming/__init__.py
@@ -1,3 +1,8 @@
-from .betfairstream import BetfairStream, HistoricalStream, HistoricalGeneratorStream
+from .betfairstream import (
+    BetfairStream,
+    HistoricalStream,
+    HistoricalGeneratorStream,
+    HistoricalGeneratorStreamBz2
+)
 from .listener import BaseListener, StreamListener
 from .stream import MarketStream, OrderStream


### PR DESCRIPTION
For my use it is useful to be able to read the historical bz2 files directly into the historical stream generator rather than having to uncompress a file back to disk and then re-read it back in as raw text, and I couldn't find any existing way to do that, so I added HistoricalGeneratorStreamBz2 that does. Is this useful to anyone else and to include in the original? and if so, is the way i've implemented it ok? I figured the alternative would be to put the if-else in HistoricalGeneratorStream._read_loop, but it looked more straightforward to include a manual parameter, compression: str, to indicate files compressed but without an extension in the former method.

modified:   betfairlightweight/endpoints/streaming.py
modified:   betfairlightweight/streaming/__init__.py
modified:   betfairlightweight/streaming/betfairstream.py

Thanks