### PR TITLE
Fix type annotations around cert files

### DIFF
--- a/betfairlightweight/apiclient.py
+++ b/betfairlightweight/apiclient.py
@@ -14,7 +14,7 @@ class APIClient(BaseClient):
         app_key: str = None,
         certs: str = None,
         locale: str = None,
-        cert_files: Union[Tuple[str], str, None] = None,
+        cert_files: Union[Tuple[str, str], str, None] = None,
         lightweight: bool = False,
         session: requests.Session = None,
     ):

--- a/betfairlightweight/baseclient.py
+++ b/betfairlightweight/baseclient.py
@@ -56,7 +56,7 @@ class BaseClient:
         app_key: str = None,
         certs: str = None,
         locale: str = None,
-        cert_files: Union[Tuple[str], str, None] = None,
+        cert_files: Union[Tuple[str, str], str, None] = None,
         lightweight: bool = False,
         session: requests.Session = None,
     ):
@@ -147,7 +147,7 @@ class BaseClient:
             return False
 
     @property
-    def cert(self) -> Union[Tuple[str], str]:
+    def cert(self) -> Union[Tuple[str, str], str]:
         """
         The betfair certificates, by default it looks for the
         certificates in /certs/.


### PR DESCRIPTION
This aligns with the documentation, and use which ultimately goes to `Session.request(cert=...)` [[docs](https://requests.readthedocs.io/en/latest/user/advanced/#client-side-certificates)].

It might have been caused by guessing that `Tuple` is like `List` and only has a single type parameter - this is the only place `Tuple` is annotated in the codebase so it doesn't look like there are similar scenarios to fix.