### PR TITLE
Dry logic around requests

### DIFF
--- a/betfairlightweight/baseclient.py
+++ b/betfairlightweight/baseclient.py
@@ -139,7 +139,9 @@ class BaseClient:
         Returns True if login_time not set or seconds since
         login time is greater half session timeout.
         """
-        return not self._login_time or time.monotonic() - self._login_time > (self.session_timeout / 2)
+        return not self._login_time or time.monotonic() - self._login_time > (
+            self.session_timeout / 2
+        )
 
     @property
     def cert(self) -> Union[Tuple[str], str]:

--- a/betfairlightweight/baseclient.py
+++ b/betfairlightweight/baseclient.py
@@ -100,7 +100,7 @@ class BaseClient:
         :param str session_token: Session token from request.
         """
         self.session_token = session_token
-        self._login_time = time.time()
+        self._login_time = time.monotonic()
 
     def get_password(self) -> str:
         """
@@ -139,7 +139,7 @@ class BaseClient:
         Returns True if login_time not set or seconds since
         login time is greater half session timeout.
         """
-        return not self._login_time or time.time() - self._login_time > (self.session_timeout / 2)
+        return not self._login_time or time.monotonic() - self._login_time > (self.session_timeout / 2)
 
     @property
     def cert(self) -> Union[Tuple[str], str]:

--- a/betfairlightweight/baseclient.py
+++ b/betfairlightweight/baseclient.py
@@ -139,12 +139,7 @@ class BaseClient:
         Returns True if login_time not set or seconds since
         login time is greater half session timeout.
         """
-        if not self._login_time or time.time() - self._login_time > (
-            self.session_timeout / 2
-        ):
-            return True
-        else:
-            return False
+        return not self._login_time or time.time() - self._login_time > (self.session_timeout / 2)
 
     @property
     def cert(self) -> Union[Tuple[str], str]:

--- a/betfairlightweight/endpoints/baseendpoint.py
+++ b/betfairlightweight/endpoints/baseendpoint.py
@@ -37,7 +37,8 @@ class BaseEndpoint:
             data=self.create_req(method, params),
             headers=self.client.request_headers,
             connect_timeout=self.connect_timeout,
-            read_timeout=self.read_timeout)
+            read_timeout=self.read_timeout,
+        )
         if self._error_handler:
             self._error_handler(data)
 

--- a/betfairlightweight/endpoints/baseendpoint.py
+++ b/betfairlightweight/endpoints/baseendpoint.py
@@ -31,7 +31,7 @@ class BaseEndpoint:
         """
         session = session or self.client.session
         request = self.create_req(method, params)
-        time_sent = time.time()
+        time_sent = time.monotonic()
         try:
             response = session.post(
                 self.url,
@@ -43,7 +43,7 @@ class BaseEndpoint:
             raise APIError(None, method, params, e)
         except Exception as e:
             raise APIError(None, method, params, e)
-        elapsed_time = time.time() - time_sent
+        elapsed_time = time.monotonic() - time_sent
 
         check_status_code(response)
         try:

--- a/betfairlightweight/endpoints/historic.py
+++ b/betfairlightweight/endpoints/historic.py
@@ -183,12 +183,15 @@ class Historic(BaseEndpoint):
         :param dict params: Params to be used in request
         :param Session session: Requests session to be used, reduces latency.
         """
-        return request(session=session or self.client.session,
-                       method="post",
-                       url=self.url + method,
-                       json=params,
-                       headers=self.headers,
-                       connect_timeout=self.connect_timeout, read_timeout=self.read_timeout)
+        return request(
+            session=session or self.client.session,
+            method="post",
+            url=self.url + method,
+            json=params,
+            headers=self.headers,
+            connect_timeout=self.connect_timeout,
+            read_timeout=self.read_timeout,
+        )
 
     @property
     def headers(self) -> dict:

--- a/betfairlightweight/endpoints/historic.py
+++ b/betfairlightweight/endpoints/historic.py
@@ -187,7 +187,7 @@ class Historic(BaseEndpoint):
         :param Session session: Requests session to be used, reduces latency.
         """
         session = session or self.client.session
-        time_sent = time.time()
+        time_sent = time.monotonic()
         try:
             response = session.post(
                 "%s%s" % (self.url, method),
@@ -199,7 +199,7 @@ class Historic(BaseEndpoint):
             raise APIError(None, method, params, e)
         except Exception as e:
             raise APIError(None, method, params, e)
-        elapsed_time = time.time() - time_sent
+        elapsed_time = time.monotonic() - time_sent
 
         check_status_code(response)
         try:

--- a/betfairlightweight/endpoints/inplayservice.py
+++ b/betfairlightweight/endpoints/inplayservice.py
@@ -111,7 +111,8 @@ class InPlayService(BaseEndpoint):
             params=params,
             headers=self.headers,
             connect_timeout=self.connect_timeout,
-            read_timeout=self.read_timeout)
+            read_timeout=self.read_timeout,
+        )
 
     @property
     def headers(self) -> dict:

--- a/betfairlightweight/endpoints/inplayservice.py
+++ b/betfairlightweight/endpoints/inplayservice.py
@@ -108,7 +108,7 @@ class InPlayService(BaseEndpoint):
         url: str = None,
     ) -> (dict, float):
         session = session or self.client.session
-        time_sent = time.time()
+        time_sent = time.monotonic()
         try:
             response = session.get(
                 url,
@@ -120,7 +120,7 @@ class InPlayService(BaseEndpoint):
             raise APIError(None, method, params, e)
         except Exception as e:
             raise APIError(None, method, params, e)
-        elapsed_time = time.time() - time_sent
+        elapsed_time = time.monotonic() - time_sent
 
         check_status_code(response)
         try:

--- a/betfairlightweight/endpoints/inplayservice.py
+++ b/betfairlightweight/endpoints/inplayservice.py
@@ -1,12 +1,9 @@
-import time
 import requests
-from typing import Union, List
+from typing import Union, List, Tuple
 
-from ..exceptions import APIError, InvalidResponse
-from ..utils import check_status_code
+from ..utils import request
 from .baseendpoint import BaseEndpoint
 from .. import resources
-from ..compat import json
 
 
 class InPlayService(BaseEndpoint):
@@ -106,29 +103,15 @@ class InPlayService(BaseEndpoint):
         params: dict = None,
         session: requests.Session = None,
         url: str = None,
-    ) -> (dict, float):
-        session = session or self.client.session
-        time_sent = time.monotonic()
-        try:
-            response = session.get(
-                url,
-                params=params,
-                headers=self.headers,
-                timeout=(self.connect_timeout, self.read_timeout),
-            )
-        except requests.ConnectionError as e:
-            raise APIError(None, method, params, e)
-        except Exception as e:
-            raise APIError(None, method, params, e)
-        elapsed_time = time.monotonic() - time_sent
-
-        check_status_code(response)
-        try:
-            response_json = json.loads(response.content.decode("utf-8"))
-        except ValueError:
-            raise InvalidResponse(response.text)
-
-        return response, response_json, elapsed_time
+    ) -> Tuple[requests.Response, dict, float]:
+        return request(
+            session=session or self.client.session,
+            method="get",
+            url=self.url,
+            params=params,
+            headers=self.headers,
+            connect_timeout=self.connect_timeout,
+            read_timeout=self.read_timeout)
 
     @property
     def headers(self) -> dict:

--- a/betfairlightweight/endpoints/keepalive.py
+++ b/betfairlightweight/endpoints/keepalive.py
@@ -37,7 +37,7 @@ class KeepAlive(BaseEndpoint):
         self, method: str = None, params: dict = None, session: requests.Session = None
     ) -> (dict, float):
         session = session or self.client.session
-        time_sent = time.time()
+        time_sent = time.monotonic()
         try:
             response = session.post(
                 self.url,
@@ -48,7 +48,7 @@ class KeepAlive(BaseEndpoint):
             raise APIError(None, exception=e)
         except Exception as e:
             raise APIError(None, exception=e)
-        elapsed_time = time.time() - time_sent
+        elapsed_time = time.monotonic() - time_sent
 
         check_status_code(response)
         try:

--- a/betfairlightweight/endpoints/keepalive.py
+++ b/betfairlightweight/endpoints/keepalive.py
@@ -40,7 +40,8 @@ class KeepAlive(BaseEndpoint):
             url=self.url,
             headers=self.client.keep_alive_headers,
             connect_timeout=self.connect_timeout,
-            read_timeout=self.read_timeout)
+            read_timeout=self.read_timeout,
+        )
         if self._error_handler:
             self._error_handler(data)
 

--- a/betfairlightweight/endpoints/keepalive.py
+++ b/betfairlightweight/endpoints/keepalive.py
@@ -1,12 +1,10 @@
-import time
 import requests
-from typing import Union
+from typing import Union, Tuple
 
 from .baseendpoint import BaseEndpoint
 from ..resources import KeepAliveResource
-from ..exceptions import KeepAliveError, APIError, InvalidResponse
-from ..utils import check_status_code
-from ..compat import json
+from ..exceptions import KeepAliveError
+from ..utils import request
 
 
 class KeepAlive(BaseEndpoint):
@@ -35,30 +33,18 @@ class KeepAlive(BaseEndpoint):
 
     def request(
         self, method: str = None, params: dict = None, session: requests.Session = None
-    ) -> (dict, float):
-        session = session or self.client.session
-        time_sent = time.monotonic()
-        try:
-            response = session.post(
-                self.url,
-                headers=self.client.keep_alive_headers,
-                timeout=(self.connect_timeout, self.read_timeout),
-            )
-        except requests.ConnectionError as e:
-            raise APIError(None, exception=e)
-        except Exception as e:
-            raise APIError(None, exception=e)
-        elapsed_time = time.monotonic() - time_sent
-
-        check_status_code(response)
-        try:
-            response_json = json.loads(response.content.decode("utf-8"))
-        except ValueError:
-            raise InvalidResponse(response.text)
-
+    ) -> Tuple[requests.Response, dict, float]:
+        response, data, duration = request(
+            session=session or self.client.session,
+            method="post",
+            url=self.url,
+            headers=self.client.keep_alive_headers,
+            connect_timeout=self.connect_timeout,
+            read_timeout=self.read_timeout)
         if self._error_handler:
-            self._error_handler(response_json)
-        return response, response_json, elapsed_time
+            self._error_handler(data)
+
+        return response, data, duration
 
     def _error_handler(
         self, response: dict, method: str = None, params: dict = None

--- a/betfairlightweight/endpoints/login.py
+++ b/betfairlightweight/endpoints/login.py
@@ -44,7 +44,8 @@ class Login(BaseEndpoint):
             headers=self.client.login_headers,
             cert=self.client.cert,
             connect_timeout=self.connect_timeout,
-            read_timeout=self.read_timeout)
+            read_timeout=self.read_timeout,
+        )
         if self._error_handler:
             self._error_handler(data)
 

--- a/betfairlightweight/endpoints/login.py
+++ b/betfairlightweight/endpoints/login.py
@@ -39,7 +39,7 @@ class Login(BaseEndpoint):
         self, method: str = None, params: dict = None, session: requests.Session = None
     ) -> (dict, float):
         session = session or self.client.session
-        time_sent = time.time()
+        time_sent = time.monotonic()
         try:
             response = session.post(
                 self.url,
@@ -52,7 +52,7 @@ class Login(BaseEndpoint):
             raise APIError(None, exception=e)
         except Exception as e:
             raise APIError(None, exception=e)
-        elapsed_time = time.time() - time_sent
+        elapsed_time = time.monotonic() - time_sent
 
         check_status_code(response)
         try:

--- a/betfairlightweight/endpoints/logininteractive.py
+++ b/betfairlightweight/endpoints/logininteractive.py
@@ -39,7 +39,7 @@ class LoginInteractive(BaseEndpoint):
         self, method: str = None, params: dict = None, session: requests.Session = None
     ) -> (dict, float):
         session = session or self.client.session
-        time_sent = time.time()
+        time_sent = time.monotonic()
         try:
             response = session.post(
                 self.url,
@@ -51,7 +51,7 @@ class LoginInteractive(BaseEndpoint):
             raise APIError(None, exception=e)
         except Exception as e:
             raise APIError(None, exception=e)
-        elapsed_time = time.time() - time_sent
+        elapsed_time = time.monotonic() - time_sent
 
         check_status_code(response)
         try:

--- a/betfairlightweight/endpoints/logininteractive.py
+++ b/betfairlightweight/endpoints/logininteractive.py
@@ -1,12 +1,10 @@
-import time
 import requests
-from typing import Union
+from typing import Union, Tuple
 
 from .baseendpoint import BaseEndpoint
 from ..resources import LoginResource
-from ..exceptions import LoginError, APIError, InvalidResponse
-from ..utils import check_status_code
-from ..compat import json
+from ..exceptions import LoginError
+from ..utils import request
 
 
 class LoginInteractive(BaseEndpoint):
@@ -37,31 +35,19 @@ class LoginInteractive(BaseEndpoint):
 
     def request(
         self, method: str = None, params: dict = None, session: requests.Session = None
-    ) -> (dict, float):
-        session = session or self.client.session
-        time_sent = time.monotonic()
-        try:
-            response = session.post(
-                self.url,
-                data=self.data,
-                headers=self.client.login_headers,
-                timeout=(self.connect_timeout, self.read_timeout),
-            )
-        except requests.ConnectionError as e:
-            raise APIError(None, exception=e)
-        except Exception as e:
-            raise APIError(None, exception=e)
-        elapsed_time = time.monotonic() - time_sent
-
-        check_status_code(response)
-        try:
-            response_json = json.loads(response.content.decode("utf-8"))
-        except ValueError:
-            raise InvalidResponse(response.text)
-
+    ) -> Tuple[requests.Response, dict, float]:
+        response, data, duration = request(
+            session=session or self.client.session,
+            method="post",
+            url=self.url,
+            data=self.data,
+            headers=self.client.login_headers,
+            connect_timeout=self.connect_timeout,
+            read_timeout=self.read_timeout)
         if self._error_handler:
-            self._error_handler(response_json)
-        return response, response_json, elapsed_time
+            self._error_handler(data)
+
+        return response, data, duration
 
     def _error_handler(
         self, response: dict, method: str = None, params: dict = None

--- a/betfairlightweight/endpoints/logininteractive.py
+++ b/betfairlightweight/endpoints/logininteractive.py
@@ -43,7 +43,8 @@ class LoginInteractive(BaseEndpoint):
             data=self.data,
             headers=self.client.login_headers,
             connect_timeout=self.connect_timeout,
-            read_timeout=self.read_timeout)
+            read_timeout=self.read_timeout,
+        )
         if self._error_handler:
             self._error_handler(data)
 

--- a/betfairlightweight/endpoints/logout.py
+++ b/betfairlightweight/endpoints/logout.py
@@ -40,7 +40,8 @@ class Logout(BaseEndpoint):
             url=self.url,
             headers=self.client.keep_alive_headers,
             connect_timeout=self.connect_timeout,
-            read_timeout=self.read_timeout)
+            read_timeout=self.read_timeout,
+        )
         if self._error_handler:
             self._error_handler(data)
         return response, data, duration

--- a/betfairlightweight/endpoints/logout.py
+++ b/betfairlightweight/endpoints/logout.py
@@ -1,12 +1,10 @@
-import time
 import requests
-from typing import Union
+from typing import Union, Tuple
 
 from .baseendpoint import BaseEndpoint
 from ..resources import LogoutResource
-from ..exceptions import LogoutError, APIError, InvalidResponse
-from ..utils import check_status_code
-from ..compat import json
+from ..exceptions import LogoutError
+from ..utils import request
 
 
 class Logout(BaseEndpoint):
@@ -35,30 +33,17 @@ class Logout(BaseEndpoint):
 
     def request(
         self, method: str = None, params: dict = None, session: requests.Session = None
-    ) -> (dict, float):
-        session = session or self.client.session
-        time_sent = time.monotonic()
-        try:
-            response = session.post(
-                self.url,
-                headers=self.client.keep_alive_headers,
-                timeout=(self.connect_timeout, self.read_timeout),
-            )
-        except requests.ConnectionError as e:
-            raise APIError(None, exception=e)
-        except Exception as e:
-            raise APIError(None, exception=e)
-        elapsed_time = time.monotonic() - time_sent
-
-        check_status_code(response)
-        try:
-            response_json = json.loads(response.content.decode("utf-8"))
-        except ValueError:
-            raise InvalidResponse(response.text)
-
+    ) -> Tuple[requests.Response, dict, float]:
+        response, data, duration = request(
+            session=session or self.client.session,
+            method="post",
+            url=self.url,
+            headers=self.client.keep_alive_headers,
+            connect_timeout=self.connect_timeout,
+            read_timeout=self.read_timeout)
         if self._error_handler:
-            self._error_handler(response_json)
-        return response, response_json, elapsed_time
+            self._error_handler(data)
+        return response, data, duration
 
     def _error_handler(
         self, response: dict, method: str = None, params: dict = None

--- a/betfairlightweight/endpoints/logout.py
+++ b/betfairlightweight/endpoints/logout.py
@@ -37,7 +37,7 @@ class Logout(BaseEndpoint):
         self, method: str = None, params: dict = None, session: requests.Session = None
     ) -> (dict, float):
         session = session or self.client.session
-        time_sent = time.time()
+        time_sent = time.monotonic()
         try:
             response = session.post(
                 self.url,
@@ -48,7 +48,7 @@ class Logout(BaseEndpoint):
             raise APIError(None, exception=e)
         except Exception as e:
             raise APIError(None, exception=e)
-        elapsed_time = time.time() - time_sent
+        elapsed_time = time.monotonic() - time_sent
 
         check_status_code(response)
         try:

--- a/betfairlightweight/endpoints/navigation.py
+++ b/betfairlightweight/endpoints/navigation.py
@@ -24,11 +24,14 @@ class Navigation(BaseEndpoint):
     def request(
         self, method: str = None, params: dict = None, session: requests.Session = None
     ) -> dict:
-        return request(session=session or self.client.session,
-                       method="get",
-                       url=self.url,
-                       headers=self.client.request_headers,
-                       read_timeout=self.read_timeout, connect_timeout=self.connect_timeout)[1]
+        return request(
+            session=session or self.client.session,
+            method="get",
+            url=self.url,
+            headers=self.client.request_headers,
+            read_timeout=self.read_timeout,
+            connect_timeout=self.connect_timeout,
+        )[1]
 
     @property
     def url(self) -> str:

--- a/betfairlightweight/endpoints/navigation.py
+++ b/betfairlightweight/endpoints/navigation.py
@@ -1,7 +1,6 @@
 import requests
 
-from ..exceptions import APIError, InvalidResponse
-from ..utils import check_status_code
+from ..utils import request
 from .baseendpoint import BaseEndpoint
 from ..compat import json
 
@@ -24,26 +23,12 @@ class Navigation(BaseEndpoint):
 
     def request(
         self, method: str = None, params: dict = None, session: requests.Session = None
-    ) -> (dict, float):
-        session = session or self.client.session
-        try:
-            response = session.get(
-                self.url,
-                headers=self.client.request_headers,
-                timeout=(self.connect_timeout, self.read_timeout),
-            )
-        except requests.ConnectionError as e:
-            raise APIError(None, method, params, e)
-        except Exception as e:
-            raise APIError(None, method, params, e)
-
-        check_status_code(response)
-        try:
-            response_json = json.loads(response.content.decode("utf-8"))
-        except ValueError:
-            raise InvalidResponse(response.text)
-
-        return response_json
+    ) -> dict:
+        return request(session=session or self.client.session,
+                       method="get",
+                       url=self.url,
+                       headers=self.client.request_headers,
+                       read_timeout=self.read_timeout, connect_timeout=self.connect_timeout)[1]
 
     @property
     def url(self) -> str:

--- a/betfairlightweight/endpoints/racecard.py
+++ b/betfairlightweight/endpoints/racecard.py
@@ -26,7 +26,8 @@ class RaceCard(BaseEndpoint):
                 method="get",
                 url=self.url,
                 connect_timeout=self.connect_timeout,
-                read_timeout=self.read_timeout)
+                read_timeout=self.read_timeout,
+            )
             if "appKey" in data:
                 return data["appKey"]
         except InvalidResponse:
@@ -101,7 +102,8 @@ class RaceCard(BaseEndpoint):
             url=self.url + self.method,
             params=params,
             headers=self.headers,
-            connect_timeout=self.connect_timeout, read_timeout=self.read_timeout,
+            connect_timeout=self.connect_timeout,
+            read_timeout=self.read_timeout,
         )
 
     @staticmethod

--- a/betfairlightweight/endpoints/racecard.py
+++ b/betfairlightweight/endpoints/racecard.py
@@ -100,7 +100,7 @@ class RaceCard(BaseEndpoint):
         self, method: str = None, params: dict = None, session: requests.Session = None
     ) -> (dict, float):
         session = session or self.client.session
-        time_sent = time.time()
+        time_sent = time.monotonic()
         url = "%s%s" % (self.url, method)
         try:
             response = session.get(
@@ -113,7 +113,7 @@ class RaceCard(BaseEndpoint):
             raise APIError(None, method, params, e)
         except Exception as e:
             raise APIError(None, method, params, e)
-        elapsed_time = time.time() - time_sent
+        elapsed_time = time.monotonic() - time_sent
 
         check_status_code(response)
         try:

--- a/betfairlightweight/streaming/cache.py
+++ b/betfairlightweight/streaming/cache.py
@@ -284,7 +284,9 @@ class MarketBookCache(BaseResource):
                 if "trd" in new_data:
                     runner.update_traded(new_data["trd"], active)
                     if self.cumulative_runner_tv:
-                        runner.total_matched = math.fsum(vol["size"] for vol in runner.traded.serialised)
+                        runner.total_matched = math.fsum(
+                            vol["size"] for vol in runner.traded.serialised
+                        )
                     calculate_tv = True
                 if "atb" in new_data:
                     runner.available_to_back.update(new_data["atb"], active)

--- a/betfairlightweight/streaming/cache.py
+++ b/betfairlightweight/streaming/cache.py
@@ -136,6 +136,20 @@ class RunnerBookCache:
         self.serialised = {}  # cache is king
         self.resource = None
 
+    def refresh(self):
+        """Refresh all refreshable properties and then serialise."""
+        # refresh all members which are instances of Available
+        self.traded.refresh()
+        self.available_to_back.refresh()
+        self.available_to_lay.refresh()
+        self.best_available_to_back.refresh()
+        self.best_available_to_lay.refresh()
+        self.best_display_available_to_back.refresh()
+        self.best_display_available_to_lay.refresh()
+        self.starting_price_back.refresh()
+        self.starting_price_lay.refresh()
+        self.serialise()
+
     def update_definition(self, definition: dict) -> None:
         self.definition = definition
         # cache values used in serialisation to prevent duplicate <get>
@@ -300,16 +314,7 @@ class MarketBookCache(BaseResource):
 
     def refresh_cache(self) -> None:
         for runner in self.runners:
-            runner.traded.refresh()
-            runner.available_to_back.refresh()
-            runner.available_to_lay.refresh()
-            runner.best_available_to_back.refresh()
-            runner.best_available_to_lay.refresh()
-            runner.best_display_available_to_back.refresh()
-            runner.best_display_available_to_lay.refresh()
-            runner.starting_price_back.refresh()
-            runner.starting_price_lay.refresh()
-            runner.serialise()
+            runner.refresh()
 
     def _process_market_definition(self, market_definition: dict) -> None:
         self.market_definition = market_definition

--- a/betfairlightweight/streaming/cache.py
+++ b/betfairlightweight/streaming/cache.py
@@ -1,3 +1,4 @@
+import math
 from typing import Union, Optional, List, Tuple, Dict
 
 from ..resources import (
@@ -283,10 +284,7 @@ class MarketBookCache(BaseResource):
                 if "trd" in new_data:
                     runner.update_traded(new_data["trd"], active)
                     if self.cumulative_runner_tv:
-                        runner.total_matched = round(
-                            sum([vol["size"] for vol in runner.traded.serialised]),
-                            2,
-                        )
+                        runner.total_matched = math.fsum(vol["size"] for vol in runner.traded.serialised)
                     calculate_tv = True
                 if "atb" in new_data:
                     runner.available_to_back.update(new_data["atb"], active)
@@ -314,11 +312,8 @@ class MarketBookCache(BaseResource):
 
             # update the total volume matched if configured and needed
             if self.calculate_market_tv and calculate_tv:
-                self.total_matched = round(
-                    sum(
-                        vol["size"] for r in self.runners for vol in r.traded.serialised
-                    ),
-                    2,
+                self.total_matched = math.fsum(
+                    vol["size"] for r in self.runners for vol in r.traded.serialised
                 )
 
     def refresh_cache(self) -> None:

--- a/betfairlightweight/streaming/cache.py
+++ b/betfairlightweight/streaming/cache.py
@@ -388,10 +388,7 @@ class MarketBookCache(BaseResource):
 
     @property
     def closed(self) -> bool:
-        if self._definition_status == "CLOSED":
-            return True
-        else:
-            return False
+        return self._definition_status == "CLOSED"
 
     @property
     def serialise(self) -> dict:

--- a/betfairlightweight/streaming/stream.py
+++ b/betfairlightweight/streaming/stream.py
@@ -128,7 +128,7 @@ class BaseStream:
 
     @staticmethod
     def _calc_latency(publish_time: int) -> float:
-        return time.time() - publish_time / 1e3
+        return time.monotonic() - publish_time / 1e3
 
     def __len__(self) -> int:
         return len(self._caches)

--- a/betfairlightweight/utils.py
+++ b/betfairlightweight/utils.py
@@ -92,16 +92,16 @@ def create_date_string(date: datetime.datetime) -> Optional[str]:
 
 
 def request(
-        session: requests.Session,
-        method: str,
-        url: str,
-        connect_timeout: float,
-        read_timeout: float,
-        headers: dict = None,
-        data: Union[dict, str] = None,
-        params: dict = None,
-        json: dict = None,
-        cert: Union[str, Tuple[str, str]] = None,
+    session: requests.Session,
+    method: str,
+    url: str,
+    connect_timeout: float,
+    read_timeout: float,
+    headers: dict = None,
+    data: Union[dict, str] = None,
+    params: dict = None,
+    json: dict = None,
+    cert: Union[str, Tuple[str, str]] = None,
 ) -> Tuple[requests.Response, dict, float]:
     """
     Make an API request and return the response, json response, and request duration.

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -332,7 +332,6 @@ class TestMarketBookCache(unittest.TestCase):
         self.market_book_cache.refresh_cache()
         mock_runner.refresh.assert_called()
 
-
     @mock.patch(
         "betfairlightweight.streaming.cache.MarketBookCache.serialise",
         new_callable=mock.PropertyMock,
@@ -502,8 +501,9 @@ class TestRunnerBookCache(unittest.TestCase):
     def test_refresh(self, mock_serialise):
         """Refresh calls refresh on all refreshable members, and also calls the serialise method."""
         # refreshable members are those which are instances of Available
-        refreshable_attrs = [k for k, v in vars(self.runner_book).items()
-                             if isinstance(v, Available)]
+        refreshable_attrs = [
+            k for k, v in vars(self.runner_book).items() if isinstance(v, Available)
+        ]
 
         # sanity check that there are refreshable attributes
         self.assertGreater(len(refreshable_attrs), 0)
@@ -520,7 +520,9 @@ class TestRunnerBookCache(unittest.TestCase):
 
         # make sure the refreshes were called
         for attr, m in mocks.items():
-            self.assertEqual(m.refresh.call_count, 1, msg=f"runner.{attr}.refresh() was not called")
+            self.assertEqual(
+                m.refresh.call_count, 1, msg=f"runner.{attr}.refresh() was not called"
+            )
         # make sure the serialise method was called
         mock_serialise.assert_called_once()
 
@@ -716,7 +718,7 @@ class TestOrderBookCache(unittest.TestCase):
                     self.order_book_cache.market_id,
                     1234,
                     self.order_book_cache.lightweight,
-                    **order_changes
+                    **order_changes,
                 )
 
     def test_update_cache_closed(self):

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -200,7 +200,7 @@ class BaseStreamTest(unittest.TestCase):
         self.stream._update_clk({"clk": 123})
         assert self.stream._clk == 123
 
-    @mock.patch("time.time", return_value=1485554805.107185)
+    @mock.patch("time.monotonic", return_value=1485554805.107185)
     def test_calc_latency(self, mock_time):
         pt = 1485554796455
         assert self.stream._calc_latency(pt) is not None


### PR DESCRIPTION
This is is a single commit on top of #508 which is best reviewed/merged first.

The main result is moving largely duplicate code into a `request(...)` method.

Further work was saved for later:
 * move request method onto `BaseEndpoint`
 * factor out unnecessary storage of headers e.g. Content-Type which is set when using `session.request(..., json=...)` - similarly some requests use `data=json.dumps(payload)` but could just use `json=payload`