### PR TITLE
Lazily evaluate log message parameters

### DIFF
--- a/betfairlightweight/streaming/betfairstream.py
+++ b/betfairlightweight/streaming/betfairstream.py
@@ -294,7 +294,7 @@ class BetfairStream:
         message_dumped += crlf
 
         logger.debug(
-            "[Subscription: %s] Sending: %s" % (self._unique_id, repr(message_dumped))
+            "[Subscription: %s] Sending: %s", self._unique_id, repr(message_dumped)
         )
         try:
             self._socket.sendall(message_dumped)

--- a/betfairlightweight/streaming/stream.py
+++ b/betfairlightweight/streaming/stream.py
@@ -43,8 +43,11 @@ class BaseStream:
         if self._lookup in data:
             self._process(data[self._lookup], publish_time)
         logger.info(
-            "[%s: %s]: %s %s added"
-            % (self, self.unique_id, len(self._caches), self._lookup)
+            "[%s: %s]: %s %s added",
+            self,
+            self.unique_id,
+            len(self._caches),
+            self._lookup,
         )
 
     def on_heartbeat(self, data: dict) -> None:
@@ -53,8 +56,11 @@ class BaseStream:
     def on_resubscribe(self, data: dict) -> None:
         self.on_update(data)
         logger.info(
-            "[%s: %s]: %s %s resubscribed"
-            % (self, self.unique_id, len(self._caches), self._lookup)
+            "[%s: %s]: %s %s resubscribed",
+            self,
+            self.unique_id,
+            len(self._caches),
+            self._lookup,
         )
 
     def on_update(self, data: dict) -> None:
@@ -66,7 +72,7 @@ class BaseStream:
             latency = self._calc_latency(publish_time)
             if latency > self._max_latency:
                 logger.warning(
-                    "[%s: %s]: Latency high: %s" % (self, self.unique_id, latency)
+                    "[%s: %s]: Latency high: %s", self, self.unique_id, latency
                 )
 
         if self._lookup in data:
@@ -90,8 +96,11 @@ class BaseStream:
         for market_id in _to_remove:
             del self._caches[market_id]
             logger.info(
-                "[%s: %s]: %s removed, %s markets in cache"
-                % (self, self.unique_id, market_id, len(self._caches))
+                "[%s: %s]: %s removed, %s markets in cache",
+                self,
+                self.unique_id,
+                market_id,
+                len(self._caches),
             )
 
     def snap(self, market_ids: list = None, publish_time: Optional[int] = None) -> list:
@@ -112,7 +121,7 @@ class BaseStream:
             self.output_queue.put(output)
 
     def _on_creation(self) -> None:
-        logger.info('[%s: %s]: "%s" created' % (self, self.unique_id, self))
+        logger.info('[%s: %s]: "%s" created', self, self.unique_id, self)
 
     def _process(self, data: list, publish_time: int) -> bool:
         # Return True if new img within data
@@ -159,8 +168,10 @@ class MarketStream(BaseStream):
                     logger.warning(
                         "[%s: %s]: Missing marketDefinition on market %s resulting "
                         "in potential missing data in the MarketBook (make sure "
-                        "EX_MARKET_DEF is requested)"
-                        % (self, self.unique_id, market_id)
+                        "EX_MARKET_DEF is requested)",
+                        self,
+                        self.unique_id,
+                        market_id,
                     )
                 market_book_cache = MarketBookCache(
                     market_id,
@@ -171,8 +182,11 @@ class MarketStream(BaseStream):
                 )
                 self._caches[market_id] = market_book_cache
                 logger.info(
-                    "[%s: %s]: %s added, %s markets in cache"
-                    % (self, self.unique_id, market_id, len(self._caches))
+                    "[%s: %s]: %s added, %s markets in cache",
+                    self,
+                    self.unique_id,
+                    market_id,
+                    len(self._caches),
                 )
 
             market_book_cache.update_cache(market_book, publish_time, True)
@@ -200,8 +214,11 @@ class OrderStream(BaseStream):
                 )
                 self._caches[market_id] = order_book_cache
                 logger.info(
-                    "[%s: %s]: %s added, %s markets in cache"
-                    % (self, self.unique_id, market_id, len(self._caches))
+                    "[%s: %s]: %s added, %s markets in cache",
+                    self,
+                    self.unique_id,
+                    market_id,
+                    len(self._caches),
                 )
 
             order_book_cache.update_cache(order_book, publish_time)
@@ -244,8 +261,11 @@ class RaceStream(BaseStream):
                 )
                 self._caches[market_id] = race_cache
                 logger.info(
-                    "[%s: %s]: %s added, %s markets in cache"
-                    % (self, self.unique_id, market_id, len(self._caches))
+                    "[%s: %s]: %s added, %s markets in cache",
+                    self,
+                    self.unique_id,
+                    market_id,
+                    len(self._caches),
                 )
 
             race_cache.update_cache(update, publish_time)
@@ -272,8 +292,11 @@ class CricketStream(BaseStream):
                 )
                 self._caches[market_id] = cricket_match_cache
                 logger.info(
-                    "[%s: %s]: %s added, %s markets in cache"
-                    % (self, self.unique_id, market_id, len(self._caches))
+                    "[%s: %s]: %s added, %s markets in cache",
+                    self,
+                    self.unique_id,
+                    market_id,
+                    len(self._caches),
                 )
 
             cricket_match_cache.update_cache(cricket_change, publish_time)

--- a/examples/examplestreamingerrhandling.py
+++ b/examples/examplestreamingerrhandling.py
@@ -67,7 +67,7 @@ class Streaming(threading.Thread):
         except Exception:
             logger.critical("MarketStreaming run error", exc_info=True)
             raise
-        logger.info("Stopped MarketStreaming {0}".format(self.streaming_unique_id))
+        logger.info("Stopped MarketStreaming %s", self.streaming_unique_id)
 
     def stop(self) -> None:
         if self.stream:

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -138,7 +138,6 @@ class StreamListenerTest(unittest.TestCase):
     def test_init(self):
         self.assertEqual(self.stream_listener.output_queue, self.output_queue)
         self.assertEqual(self.stream_listener.max_latency, self.max_latency)
-        self.assertFalse(self.stream_listener.debug)
         self.assertTrue(self.stream_listener.update_clk)
         self.assertFalse(self.stream_listener.calculate_market_tv)
         self.assertFalse(self.stream_listener.cumulative_runner_tv)


### PR DESCRIPTION
Logging like this:

    logger.debug("Hello, %s" % name)

causes the message string to always be interpolated even if the message is not going to be logged.

Logging like this:

    logger.debug("Hello, %s", name)

will mean the string is only ever interpolated if it will be logged.

In practice here this will make little difference if the log level is INFO
or above, but it does mean a `if` statement can be removed from StreamListener.

See:

https://docs.python.org/3/howto/logging.html#optimization
https://stackoverflow.com/questions/4148790/lazy-logger-message-string-evaluation