### PR TITLE
Remove unnecessary conversion of dict values to list

### DIFF
--- a/betfairlightweight/streaming/stream.py
+++ b/betfairlightweight/streaming/stream.py
@@ -97,7 +97,7 @@ class BaseStream:
     def snap(self, market_ids: list = None, publish_time: Optional[int] = None) -> list:
         return [
             cache.create_resource(self.unique_id, snap=True, publish_time=publish_time)
-            for cache in list(self._caches.values())
+            for cache in self._caches.values()
             if cache.active and (market_ids is None or cache.market_id in market_ids)
         ]
 


### PR DESCRIPTION
As `{}.values()` is already iterable there's no need to conver them to a list:

    d = {'a': 1, 'b': 2}
    a = [n for n in list(d.values())]
    b = [n for n in d.values()]

    a == b  # True