### PR TITLE
Improve performance of BaseStream.snap

### DIFF
--- a/betfairlightweight/streaming/stream.py
+++ b/betfairlightweight/streaming/stream.py
@@ -95,11 +95,25 @@ class BaseStream:
             )
 
     def snap(self, market_ids: list = None, publish_time: Optional[int] = None) -> list:
-        return [
-            cache.create_resource(self.unique_id, snap=True, publish_time=publish_time)
-            for cache in list(self._caches.values())
-            if cache.active and (market_ids is None or cache.market_id in market_ids)
-        ]
+        # yes you can avoid the if and have fewer lines of code but it's faster
+        # to treat these cases separately as you can avoid list(...) and some
+        # conditionals!
+        if market_ids:
+            return [
+                cache.create_resource(
+                    self.unique_id, snap=True, publish_time=publish_time
+                )
+                for market_id in market_ids
+                if (cache := self._caches.get(market_id)) is not None and cache.active
+            ]
+        else:
+            return [
+                cache.create_resource(
+                    self.unique_id, snap=True, publish_time=publish_time
+                )
+                for cache in list(self._caches.values())
+                if cache.active
+            ]
 
     def on_process(self, caches: list, publish_time: Optional[int] = None) -> None:
         if self.output_queue:


### PR DESCRIPTION
This speeds up snap by splitting it into two cases, where market_ids is None or not.

If market_ids are specified then we can avoid construcing a list of all of self._caches.values(). To do this the walrus operator is used. This means that Python >= 3.8 is required, but that is already the oldest tested Python version.

If market_ids is None then we can avoid the conditional on market_ids being None or not on each iteration.

Benchmark:

https://gist.github.com/petedmarsh/71337df6a09d47e5f55d2f0d60e15cf7
```
Results (Python 3.11.3):

                                                                Benchmarks, repeat=5, number=5
     ┌──────────────────────────────────────────────────────────────────┬─────────┬─────────┬─────────┬────────────────┬─────────────────┬────────────────┐
     │                                                        Benchmark │ Min     │ Max     │ Mean    │ Min (+)        │ Max (+)         │ Mean (+)       │
     ├──────────────────────────────────────────────────────────────────┼─────────┼─────────┼─────────┼────────────────┼─────────────────┼────────────────┤
     │ Snap Original vs New with specified market_ids and no contention │ 0.817   │ 0.830   │ 0.827   │ 0.226 (3.6x)   │ 0.231 (3.6x)    │ 0.228 (3.6x)   │
     │      Snap Original vs New with market_ids=None and no contention │ 0.360   │ 0.365   │ 0.363   │ 0.316 (1.1x)   │ 0.323 (1.1x)    │ 0.319 (1.1x)   │
     │         Snap Original vs New with market_ids=None and contention │ 0.361   │ 0.374   │ 0.367   │ 0.323 (1.1x)   │ 0.342 (1.1x)    │ 0.330 (1.1x)   │
     │    Snap Original vs New with specified market_ids and contention │ 0.708   │ 0.722   │ 0.711   │ 0.215 (3.3x)   │ 0.219 (3.3x)    │ 0.217 (3.3x)   │
     └──────────────────────────────────────────────────────────────────┴─────────┴─────────┴─────────┴────────────────┴─────────────────┴────────────────┘
```