### PR TITLE
Improve performance of socket code

### DIFF
--- a/tests/test_betfairstream.py
+++ b/tests/test_betfairstream.py
@@ -283,31 +283,31 @@ class BetfairStreamTest(unittest.TestCase):
         self.betfair_stream._running = False
         time.sleep(0.1)
 
-        mock_data.assert_called_with("{}")
+        mock_data.assert_called_with("{}\r\n")
         mock_receive_all.assert_called_with()
         assert self.betfair_stream.datetime_last_received is not None
         assert self.betfair_stream.receive_count > 0
 
     def test_receive_all(self):
-        mock_socket = mock.Mock()
+        mock_socket_file = mock.Mock()
         data_return_value = b'{"op":"status"}\r\n'
-        mock_socket.recv.return_value = data_return_value
-        self.betfair_stream._socket = mock_socket
+        mock_socket_file.readline.return_value = data_return_value
+        self.betfair_stream._socket_file = mock_socket_file
 
         data = self.betfair_stream._receive_all()
-        assert data == ""
+        assert data is None
 
         self.betfair_stream._running = True
         data = self.betfair_stream._receive_all()
-        mock_socket.recv.assert_called_with(self.buffer_size)
-        assert data == data_return_value.decode("utf-8")
+        mock_socket_file.readline.assert_called_with()
+        assert data == data_return_value.decode("utf-8").strip()
 
     @mock.patch("betfairlightweight.streaming.betfairstream.BetfairStream.stop")
     def test_receive_all_closed(self, mock_stop):
-        mock_socket = mock.Mock()
+        mock_socket_file = mock.Mock()
         data_return_value = b""
-        mock_socket.recv.return_value = data_return_value
-        self.betfair_stream._socket = mock_socket
+        mock_socket_file.readline.return_value = data_return_value
+        self.betfair_stream._socket_file = mock_socket_file
         self.betfair_stream._running = True
 
         with self.assertRaises(SocketError):
@@ -316,22 +316,22 @@ class BetfairStreamTest(unittest.TestCase):
 
     @mock.patch("betfairlightweight.streaming.betfairstream.BetfairStream.stop")
     def test_receive_all_error(self, mock_stop):
-        mock_socket = mock.Mock()
-        self.betfair_stream._socket = mock_socket
+        mock_socket_file = mock.Mock()
+        self.betfair_stream._socket_file = mock_socket_file
 
         self.betfair_stream._running = True
-        mock_socket.recv.side_effect = socket.error()
+        mock_socket_file.readline.side_effect = socket.error()
         with self.assertRaises(SocketError):
             self.betfair_stream._receive_all()
         mock_stop.assert_called_with()
 
     @mock.patch("betfairlightweight.streaming.betfairstream.BetfairStream.stop")
     def test_receive_all_timeout(self, mock_stop):
-        mock_socket = mock.Mock()
-        self.betfair_stream._socket = mock_socket
+        mock_socket_file = mock.Mock()
+        self.betfair_stream._socket_file = mock_socket_file
 
         self.betfair_stream._running = True
-        mock_socket.recv.side_effect = socket.timeout()
+        mock_socket_file.readline.side_effect = socket.timeout()
         with self.assertRaises(SocketError):
             self.betfair_stream._receive_all()
         mock_stop.assert_called_with()


### PR DESCRIPTION
This fixes an admitedly rare-in-practice issue where complete messages get stuck in a buffer but also speeds up the receiving of data from the socket in all cases.

The current socket code waits until the last received data ends with a linefeed. It's not gauarenteed that each messsage sent will be read by a single call to `socket.recv` - the message could be larger than the buffer, or several small messages could be read together. It's possible for complete messages to be stuck in the buffer until a call to `recv` returns bytes that end with a linefeed.

For the sake of illustrating the issue imagine the buffer is 16 bytes. We can `.recv` a full 16 bytes of data containing one complete and one partial message. (Note it's possible for this to happen even if the amount of received data is smaller than the buffer).

    part = self._socket.recv(16)
    part == b'{"a":"b"}\r\n{"d":'
    # now part will be appended to data and {"a":"b"} will not be
    # pushed to self._data immediately

This issue is fixed by using socket.makefile as it will split the data received on each linefeed.

`self._socket_file` is read-only, it could be made writable too and the places where writes are made to the socket could be changed to use it too, this would work. However, there's no issue reading from the socket using `self._socket_file` only and writing using the raw socket, and there's nothing to be gained by writing via `self._socket_file` so that has not been changed.

Benchmark

https://gist.github.com/petedmarsh/0a2775ec706156b892d40a67cb017bef

    Results (Python 3.11.3)
                                                       Benchmarks, repeat=5, number=5
    ┌─────────────────────────────────────────────────┬─────────┬─────────┬─────────┬─────────────────┬─────────────────┬─────────────────┐
    │                                       Benchmark │ Min     │ Max     │ Mean    │ Min (+)         │ Max (+)         │ Mean (+)        │
    ├─────────────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────────────┼─────────────────┼─────────────────┤
    │ Original Client Code vs socket.makefile version │ 5.195   │ 5.965   │ 5.641   │ 3.827 (1.4x)    │ 3.832 (1.6x)    │ 3.830 (1.5x)    │
    └─────────────────────────────────────────────────┴─────────┴─────────┴─────────┴─────────────────┴─────────────────┴─────────────────┘