### PR TITLE
Fix utcnow deprecation for python3.12

### DIFF
--- a/betfairlightweight/resources/baseresource.py
+++ b/betfairlightweight/resources/baseresource.py
@@ -3,6 +3,7 @@ import datetime
 from typing import Union, Optional
 
 from ..compat import basestring, integer_types, json, parse_datetime
+from ..utils import utcfromtimestamp, utcnow
 
 
 class BaseResource:
@@ -10,7 +11,7 @@ class BaseResource:
 
     def __init__(self, **kwargs):
         self.elapsed_time = kwargs.pop("elapsed_time", None)
-        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        now = utcnow()
         self._datetime_created = now
         self._datetime_updated = now
         self._data = kwargs
@@ -31,9 +32,7 @@ class BaseResource:
                 return
         elif isinstance(value, integer_types):
             try:
-                return datetime.datetime.fromtimestamp(
-                    value / 1e3, tz=datetime.timezone.utc
-                )
+                return utcfromtimestamp(value / 1e3)
             except (ValueError, OverflowError, OSError):
                 return
 

--- a/betfairlightweight/streaming/betfairstream.py
+++ b/betfairlightweight/streaming/betfairstream.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from ..exceptions import SocketError, ListenerError
 from ..compat import json
+from ..utils import utcnow
 from .listener import BaseListener
 
 logger = logging.getLogger(__name__)
@@ -225,9 +226,7 @@ class BetfairStream:
             received_data_raw = self._receive_all()
             if self._running:
                 self.receive_count += 1
-                self.datetime_last_received = datetime.datetime.now(
-                    tz=datetime.timezone.utc
-                )
+                self.datetime_last_received = utcnow()
                 received_data_split = received_data_raw.split(self.__CRLF)
                 for received_data in received_data_split:
                     if received_data:

--- a/betfairlightweight/streaming/stream.py
+++ b/betfairlightweight/streaming/stream.py
@@ -3,6 +3,7 @@ import logging
 import time
 from typing import Optional
 
+from ..utils import utcnow
 from .cache import CricketMatchCache, MarketBookCache, OrderBookCache, RaceCache
 
 logger = logging.getLogger(__name__)
@@ -33,8 +34,8 @@ class BaseStream:
         self._updates_processed = 0
         self._on_creation()
 
-        self.time_created = datetime.datetime.now(tz=datetime.timezone.utc)
-        self.time_updated = datetime.datetime.now(tz=datetime.timezone.utc)
+        self.time_created = utcnow()
+        self.time_updated = utcnow()
 
     def on_subscribe(self, data: dict) -> None:
         self._update_clk(data)
@@ -147,7 +148,7 @@ class BaseStream:
             self._initial_clk = initial_clk
         if clk:
             self._clk = clk
-        self.time_updated = datetime.datetime.now(tz=datetime.timezone.utc)
+        self.time_updated = utcnow()
 
     @staticmethod
     def _calc_latency(publish_time: int) -> float:

--- a/betfairlightweight/utils.py
+++ b/betfairlightweight/utils.py
@@ -88,3 +88,14 @@ def create_date_string(date: datetime.datetime) -> Optional[str]:
     """
     if date:
         return date.strftime(BETFAIR_DATE_FORMAT)
+
+
+def utcnow():
+    """return timezone naive now"""
+    return datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None)
+
+
+def utcfromtimestamp(ts):
+    return datetime.datetime.fromtimestamp(ts, tz=datetime.timezone.utc).replace(
+        tzinfo=None
+    )


### PR DESCRIPTION
Python 3.12 deprecates `datetime.datetime.utcnow` and `datetime.datetime.utcfromtimestamp`:
https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow

This PR makes the recommended change that is compatible with pre-python 3.12 versions.