### PR TITLE
betDelayModels added to streaming MD (fuck you betfair)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 Release History
 ---------------
 
+2.21.2 (2025-09-11)
++++++++++++++++++++
+
+**Improvements**
+
+- betDelayModels added to streaming MD (fuck you betfair)
+
 2.21.1 (2025-08-20)
 +++++++++++++++++++
 

--- a/betfairlightweight/__version__.py
+++ b/betfairlightweight/__version__.py
@@ -1,6 +1,6 @@
 __title__ = "betfairlightweight"
 __description__ = "Lightweight python wrapper for Betfair API-NG"
 __url__ = "https://github.com/betcode-org/betfair"
-__version__ = "2.21.1"
+__version__ = "2.21.2"
 __author__ = "Liam Pauling"
 __license__ = "MIT"

--- a/betfairlightweight/resources/streamingresources.py
+++ b/betfairlightweight/resources/streamingresources.py
@@ -126,6 +126,7 @@ class MarketDefinition:
         keyLineDefinition: dict = None,
         raceType: str = None,
         suspendReason: str = None,
+        betDelayModels: list = None,
         **kwargs,
     ):
         self.bet_delay = betDelay
@@ -170,6 +171,7 @@ class MarketDefinition:
         )
         self.race_type = raceType
         self.suspend_reason = suspendReason
+        self.bet_delay_models = betDelayModels
 
         self.name = name  # historic data only
         self.event_name = eventName  # historic data only


### PR DESCRIPTION
https://forum.developer.betfair.com/forum/developer-program/announcements/42128-update-betfair-api-release-4th-september-%E2%80%93-new-field-betdelaymodels?p=42188#post42188

https://github.com/betfair/stream-api-sample-code/blob/master/ESASwaggerSchema.json#L638