### PR TITLE
Fixes handling of a split frame message

### DIFF
--- a/betfairlightweight/streaming/betfairstream.py
+++ b/betfairlightweight/streaming/betfairstream.py
@@ -243,7 +243,7 @@ class BetfairStream:
         data = b""
         crlf_bytes = bytes(self.__CRLF, encoding=self.__encoding)
 
-        while self._running and data[-2:] != crlf_bytes:
+        while self._running and not data.endswith(crlf_bytes):
             try:
                 part = self._socket.recv(self.buffer_size)
             except (socket.timeout, socket.error) as e:

--- a/betfairlightweight/streaming/betfairstream.py
+++ b/betfairlightweight/streaming/betfairstream.py
@@ -240,10 +240,10 @@ class BetfairStream:
         """Whilst socket is running receives data from socket,
         till CRLF is detected.
         """
-        (data, part) = ("", "")
+        data = b""
         crlf_bytes = bytes(self.__CRLF, encoding=self.__encoding)
 
-        while self._running and part[-2:] != crlf_bytes:
+        while self._running and data[-2:] != crlf_bytes:
             try:
                 part = self._socket.recv(self.buffer_size)
             except (socket.timeout, socket.error) as e:
@@ -264,8 +264,8 @@ class BetfairStream:
                 else:
                     return  # 165, prevents error if stop is called mid recv
 
-            data += part.decode(self.__encoding)
-        return data
+            data += part
+        return data.decode(self.__encoding)
 
     def _data(self, received_data: str) -> None:
         """Sends data to listener, if False is returned; socket

--- a/tests/test_betfairstream.py
+++ b/tests/test_betfairstream.py
@@ -310,6 +310,37 @@ class BetfairStreamTest(unittest.TestCase):
         mock_socket.recv.assert_called_with(self.buffer_size)
         assert data == data_return_value.decode("utf-8")
 
+    def test_receive_part_split(self):
+        part1 = b'{"op":"ccm","desc":"England v NZ \xe2'
+        part2 = b'\x80\x94 Test"}\r\n'
+        expected = part1 + part2
+
+        mock_socket = mock.Mock()
+        mock_socket.recv.side_effect = [part1, part2]
+        self.betfair_stream._socket = mock_socket
+        self.betfair_stream._running = True
+
+        data = self.betfair_stream._receive_all()
+
+        assert data == expected.decode("utf-8")
+        assert mock_socket.recv.call_count == 2
+        mock_socket.recv.assert_called_with(self.buffer_size)
+
+    def test_receive_crlf_split(self):
+        part1 = b'{"op":"status"}\r'
+        part2 = b"\n"
+        expected = part1 + part2
+
+        mock_socket = mock.Mock()
+        mock_socket.recv.side_effect = [part1, part2]
+        self.betfair_stream._socket = mock_socket
+        self.betfair_stream._running = True
+
+        data = self.betfair_stream._receive_all()
+
+        assert data == expected.decode("utf-8")
+        assert mock_socket.recv.call_count == 2
+
     @mock.patch("betfairlightweight.streaming.betfairstream.BetfairStream.stop")
     def test_receive_all_closed(self, mock_stop):
         mock_socket = mock.Mock()


### PR DESCRIPTION
Fixes UnicodeDecodeError when receiving messages split across reads, seen occasionally on the cricket stream. Happens when a multi byte character lands at the buffer size split.

For example, a multi-byte character such as an em dash
```
frame: {"a":"b—c"}\r\n
recv 1:  b'{"a":"b\xe2'
recv 2: b'\x80\x94c"}\r\n'
```

Currently untested, I still need to test against the socket.